### PR TITLE
Set links

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,19 @@
+
+ jQuery(document).ready(function() {
+ // alert(window.location.search)
+     if(window.location.search.match(/linkback/)) { 
+       console.log('1=' +window.location.search);
+       if(!window.location.search.match(/linkback=https%3A%2F%2Fgithub.com/)) {
+        if(!window.location.search.match(/\w+$/)) {
+		  window.location.search = window.location.search.replace(/linkback=/,'linkback=https%3A%2F%2Fgithub.com');
+		}
+		else if(!window.location.search.match(/raw.githubusercontent.com/)) {
+			window.location.search = window.location.search.replace(/linkback=/,'linkback=https%3A%2F%2Fraw.githubusercontent.com');
+		}
+	   }		
+	    console.log('2=' +window.location.search);
+	  }
+     }
+	 );   
+ 
+///http://www.epicurus.bz/greebo/doku.php?id=playgroun:repo_2&linkback=https%3A%2F%2Fraw.githubusercontent.com%2Fturnermm%2FTextInsert%2Fmaster%2Fplugin.info.txt

--- a/syntax.php
+++ b/syntax.php
@@ -62,7 +62,8 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
      * Create output
      */
     function render($mode, Doku_Renderer $renderer, $data) {
-
+        global $INPUT;
+        msg(print_r($_REQUEST,1));
         // construct requested URL
         $base  = hsc($data[0]);
         $title = ($data[1] ? hsc($data[1]) : $base);
@@ -157,25 +158,25 @@ class syntax_plugin_repo extends DokuWiki_Syntax_Plugin {
             $data = preg_replace_callback(
                 '#href\s*=\s*("|\')(.*?)\1#ms',
                 function ($matches) {
-                    global $ID;
-                    $link = wl($ID);
-                    // return 'href=' . $matches[1] . $link . $matches[1] . "'";
-                     if(strpos($matches[2],'tree')){
+                    global $ID,$conf;
+                    if($conf['userewrite']) {
+                        $connector = "?";            
+                    }
+                    else {
+                        $connector = "&amp;";
+                    }    
+                   
+                    $link = wl($ID);                   
+                     if(strpos($matches[2],'tree')|| strpos($matches[2],'commit')){
                          $matches[2].='/';
-                       //  msg($matches[2]);
-                       //  return $matches[2];
                      }
-                     else if(strpos($matches[2],'blob')){                         
-                         $matches[2]= 'href=' . $matches[1] . $link . $matches[1] .  
-                         '&linkback="' . urlencode($matches[2]) . '"';
-                        // msg($matches[2],1);
-                         return ($matches[2]);
-                     }
-                     else {
-                         return $matches[0];
-                     }
-                    $matches[2]= 'href=' . $matches[1] . $link . //$matches[1] .  
-                         '&linkback=' . urlencode($matches[2]) . '"';
+                     else if(strpos($matches[2],'blob')=== false){
+                         msg($matches[0]);
+                        return $matches[0];
+                     }   
+                     
+                    $matches[2]= 'href=' . $matches[1] . $link . $connector .
+                         'linkback=' . urlencode($matches[2]) . '"';                     
                     return $matches[2];
                 },
                 $data


### PR DESCRIPTION
This is an adaptation of the [repo plugin](https://www.dokuwiki.org/plugin:repo) .  The original seems to be aimed at repos stored  in Google code. This adaptation retains the original's features but adds the facility to access github repos  and code, including the facility to drill into github folders and to read and display their files.  The files are displayed with Geshi highlighting .The original throws a fatal flaw, which crashes the plugin, a result of the change of location of Geshi.
 
